### PR TITLE
Add Docker deployment setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY LeetpeekOS_kunskapsbas/ /usr/share/nginx/html/

--- a/LeetpeekOS_kunskapsbas/package.json
+++ b/LeetpeekOS_kunskapsbas/package.json
@@ -4,7 +4,8 @@
   "description": "Denna kunskapsbas beskriver **Leetpeek OS v1** – ett internt, statiskt och helt **Mermaid‑diagram-baserat** mini-OS för de 4 grundarna.  All implementering sker som **separata HTML-filer** med Mermaid.js. **Ingen brödtext** visas i själva webbgränssnittet – endast diagram.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "npx serve ."
   },
   "keywords": [],
   "author": "",

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# LeetpeekOS_version2
+# LeetpeekOS version 2
+
+This repository hosts the static Leetpeek OS knowledge base.
+
+## Deploy with Docker
+
+Build the image and serve the site with Nginx:
+
+```bash
+docker build -t leetpeekos .
+docker run --rm -p 8080:80 leetpeekos
+```
+
+Open [http://localhost:8080](http://localhost:8080) to view the site.
+
+## Local development
+
+From the `LeetpeekOS_kunskapsbas` directory you can start a simple static server:
+
+```bash
+npm start
+```
+
+This uses `npx serve` to preview the site locally.


### PR DESCRIPTION
## Summary
- add Dockerfile to serve the knowledge base via Nginx
- document Docker deployment and local dev start script
- enable `npm start` using `npx serve` for quick previews

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(fails: 403 Forbidden - GET https://registry.npmjs.org/serve)*
- `docker build -q .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5854c57f4832e8f27665e13ff89cb